### PR TITLE
Fix Safari iOS rendering bug for reroll hint

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -227,7 +227,6 @@ button {
     color: #8a7280;
     font-size: 0.9rem;
     font-style: italic;
-    animation: slideInOut 2s infinite ease-in-out;
 }
 
 @keyframes slideInOut {
@@ -237,6 +236,7 @@ button {
 
 .card.introCard .reroll-hint {
     display: block;
+    animation: slideInOut 2s infinite ease-in-out;
 }
 
 .reroll-anim {


### PR DESCRIPTION
Fix Safari iOS rendering bug for reroll hint. 

When deploying the site to GitHub pages (and frequently viewed via iOS), the "Reroll ➔" text would appear incorrectly on all cards. The issue stems from Safari on iOS having a layout bug where elements with a continuous animation (`infinite`) don't properly hide when `display: none` is applied. 

This fix removes the `animation` property from `.reroll-hint` (which is normally hidden) and adds it only to the `.card.introCard .reroll-hint` selector where it is actively set to `display: block`. This resolves the glitch without affecting the intended behavior on the intro card.

---
*PR created automatically by Jules for task [16799421152673044120](https://jules.google.com/task/16799421152673044120) started by @yashpthk*